### PR TITLE
Fleck2+demo+compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,18 @@ Install via NuGet
 
 Building
 --------
-Run build.bat from the commandline and release dll will be
+```
+1. "Clone or Download" -> "Download zip" -> Unzip it.
+2. Run build.bat from the commandline and release dll will be
 created for NET 2.0, 3.5, 4.0 and 4.5.
+```
+```
+To do building just demo and test this:
+1. Go to "demo/" and start "Compile.bat", or start "/build.bat".
+2. Wait compilation. Compiled files will be saved in "/demo/bin/Release", and Fleck2.dll there is exists too.
+3. Run "Fleck2.Demo.exe" from the folder "\demo\bin\Release\".
+4. Type any messages in opened "client.html", and see this in the server console.
+```
 
 Requirements
 ------------

--- a/build.bat
+++ b/build.bat
@@ -2,8 +2,12 @@
 
 set config=Release
 set platform=AnyCpu
-set outputdir=%cwd%\bin
+:: Use current directory
 set cwd=%CD%
+:: Switch disk and folder
+cd /D ^"%cwd%^"
+:: Use current dirrectory for output directory
+set outputdir=%cwd%\bin
 set commonflags=/p:Configuration=%config% /p:Platform=%platform% /p:DebugSymbols=false /p:DebugType=None
 
 set fdir=%WINDIR%\Microsoft.NET\Framework
@@ -12,10 +16,14 @@ set msbuild=%fdir%\v4.0.30319\msbuild.exe
 :build
 echo ---------------------------------------------------------------------
 echo Compile started...
-%msbuild% src\Fleck2.csproj %commonflags% /tv:2.0 /p:TargetFrameworkVersion=v2.0 /p:OutputPath="%outputdir%\NET20"
-%msbuild% src\Fleck2.csproj %commonflags% /tv:3.5 /p:TargetFrameworkVersion=v3.5 /p:OutputPath="%outputdir%\NET35"
-%msbuild% src\Fleck2.csproj %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v4.0 /p:OutputPath="%outputdir%\NET40"
-%msbuild% src\Fleck2.csproj %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v4.5 /p:OutputPath="%outputdir%\NET45"
+::Add quotes for folderw with spaces
+%msbuild% "src\Fleck2.csproj" %commonflags% /tv:2.0 /p:TargetFrameworkVersion=v2.0 /p:OutputPath="%outputdir%\NET20"
+%msbuild% "src\Fleck2.csproj" %commonflags% /tv:3.5 /p:TargetFrameworkVersion=v3.5 /p:OutputPath="%outputdir%\NET35"
+%msbuild% "src\Fleck2.csproj" %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v4.0 /p:OutputPath="%outputdir%\NET40"
+:: After compile for .NET Framework 4.0 this will working for net40
+%msbuild% "demo\Fleck2.Demo.csproj" /property:Configuration=Release /p:IntermediateOutputPath="../demo/bin/Release/"
+%msbuild% "src\Fleck2.csproj" %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v4.5 /p:OutputPath="%outputdir%\NET45"
+%msbuild% "src\Fleck2.csproj" %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v4.5 /p:OutputPath="%outputdir%\NET45"
 
 :done
 echo.
@@ -24,3 +32,5 @@ echo Compile finished....
 goto exit
 
 :exit
+::Don't exit, to be able to read errors.
+pause

--- a/demo/Compile.bat
+++ b/demo/Compile.bat
@@ -1,0 +1,7 @@
+﻿:: This file need to compile demo on .NET Framework 4.0
+:: output files will be the folder /bin/Release
+@echo off
+set fdir=%WINDIR%\Microsoft.NET\Framework
+set msbuild=%fdir%\v4.0.30319\msbuild.exe
+%msbuild% /p:IntermediateOutputPath="../bin/Release/" /property:Configuration=Release Fleck2.Demo.csproj
+pause

--- a/demo/Compile.bat
+++ b/demo/Compile.bat
@@ -3,5 +3,5 @@
 @echo off
 set fdir=%WINDIR%\Microsoft.NET\Framework
 set msbuild=%fdir%\v4.0.30319\msbuild.exe
-%msbuild% /p:IntermediateOutputPath="../bin/Release/" /property:Configuration=Release Fleck2.Demo.csproj
+%msbuild% /p:IntermediateOutputPath="bin/Release/" /property:Configuration=Release Fleck2.Demo.csproj
 pause

--- a/demo/Program.cs
+++ b/demo/Program.cs
@@ -19,10 +19,17 @@ namespace Fleck2.Demo
                     Console.WriteLine("Open!");
                     allSockets.Add(socket);
                 };
+				
+				//This is triggering twise and calling double closing, when tab is closed in browser. How to fix this?
                 socket.OnClose = () =>
                 {
-                    Console.WriteLine("Close!");
-                    allSockets.Remove(socket);
+                    Console.Write("Try to close... ");
+                    try{
+						allSockets.Remove(socket);
+						Console.Write(" Successfuly Closed!\n");
+					}catch{
+						Console.WriteLine(" Was been already closed!\n");
+					}
                 };
                 socket.OnMessage = message =>
                 {

--- a/demo/client.html
+++ b/demo/client.html
@@ -12,7 +12,11 @@
             inc.innerHTML += "connecting to server ..<br/>";
 
             // create a new websocket and connect
-            window.ws = new wsImpl('ws://localhost:8181/consoleappsample', 'my-protocol');
+//comment this string, because this working only in Mozilla for me.
+        //    window.ws = new wsImpl('ws://localhost:8181/consoleappsample', 'my-protocol');
+
+// This working for Google Chrome, Chromium, and 360 Extreme Explorer
+            window.ws = new wsImpl('ws://localhost:8181/consoleappsample');
 
             // when data is comming from the server, this metod is called
             ws.onmessage = function (evt) {


### PR DESCRIPTION
Fix compile errors, client connetion and add instructions for compilation:
________
3 files changed, 1 file added.
build.bat
 - use %cwd%, after set pathway there.
 - add quotes for pathway if this pathway contains whitespaces.
 - switch disk go to folder, before compile. Because this was been saved in the disk:\bin\
 - add string to compile Fleck2.Demo, after compilation .dll for net40. This will be in the folder /demo/bin/Release/
 - don't exit, and pause. Now there is able to read errors.

/demo/client.html
 - Don't use second parameter, because this not working in some browsers. Without this parameter this working good too.

/demo/Program.cs
 - Add try-catch when program try to close socket. Don't show throw exception, and just notify about status.
    This function calls twise, when browser tab is closed.

\demo\Compile.bat - Add this file to compile just demo, without dlls.

Compilation and demo was been tested on .NET Framework 4.0 on Windows XP (+Google Chrome 34.0.1847.131m).
__________
